### PR TITLE
Fix public room attachments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-slack-attachment",
   "description": "Re-enable `slack-attachment` event for hubot-slack",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Leandro López <inkel.ar@gmail.com> (inkel)",
   "license": "MIT",
   "keywords": [

--- a/src/slack-attachment.coffee
+++ b/src/slack-attachment.coffee
@@ -13,7 +13,7 @@ module.exports = (robot) ->
   return robot.logger.error "Missing configuration HUBOT_SLACK_INCOMING_WEBHOOK" unless options.webhook?
 
   getChannel = (msg) ->
-    if msg.match /^[#@]/
+    if msg.room.match /^[#@]/
       # the channel already has an appropriate prefix
       msg.room
     else if msg.user && msg.room == msg.user.name


### PR DESCRIPTION
The regex in `getChannel` was testing the entire `msg` object instead of `msg.room`, causing the expression to be truthy and `msg.room` was returned without prefixing with `#`, even though `msg.room` didn't have an `#` prefix. In turn, this caused Hubot to attempt to send attachments to an invalid room. This fixes the issue by explicitly testing `msg.room` in the first branch.